### PR TITLE
fix: aria-hidden button icons

### DIFF
--- a/src/docs/components/ComponentCard.svelte
+++ b/src/docs/components/ComponentCard.svelte
@@ -17,7 +17,7 @@
 	size="large"
 >
 	<VStack gap={2}>
-		<Icon icon={component.icon} size="1.5rem" />
+		<Icon icon={component.icon} size="1.5rem" aria-hidden />
 		<Text size="small">{component.name}</Text>
 	</VStack>
 </Button>

--- a/src/lib/internal/Button.svelte
+++ b/src/lib/internal/Button.svelte
@@ -133,11 +133,11 @@
 
 {#snippet content()}
 	{#if leadingIcon && !loading}
-		<Icon size="1.15rem" icon={leadingIcon} />
+		<Icon size="1.15rem" icon={leadingIcon} aria-hidden />
 	{/if}
 	{@render children?.()}
 	{#if trailingIcon}
-		<Icon size="1.15rem" icon={trailingIcon} />
+		<Icon size="1.15rem" icon={trailingIcon} aria-hidden />
 	{/if}
 {/snippet}
 


### PR DESCRIPTION
Mark icons within buttons as `aria-hidden` from screen readers, because the buttons already contain text information.
