### PR TITLE
feat: mandatory IconButton labels

### DIFF
--- a/src/docs/components/Footer.svelte
+++ b/src/docs/components/Footer.svelte
@@ -1,18 +1,6 @@
 <script lang="ts">
-	import {
-		Card,
-		Container,
-		Heading,
-		HStack,
-		Icon,
-		IconButton,
-		Link,
-		Stack,
-		Text,
-		theme,
-		Theme,
-		VStack,
-	} from '@immich/ui';
+	import ThemeSwitcher from '$lib/components/ThemeSwitcher/ThemeSwitcher.svelte';
+	import { Card, Container, Heading, HStack, Icon, Link, Stack, Text, VStack } from '@immich/ui';
 	import {
 		mdiAndroid,
 		mdiApple,
@@ -21,16 +9,8 @@
 		mdiOfficeBuildingOutline,
 		mdiReddit,
 		mdiServerOutline,
-		mdiWeatherNight,
-		mdiWeatherSunny,
 		mdiWeb,
 	} from '@mdi/js';
-
-	const handleToggleTheme = () => {
-		theme.value = theme.value === Theme.Dark ? Theme.Light : Theme.Dark;
-	};
-
-	const themeIcon = $derived(theme.value === Theme.Light ? mdiWeatherSunny : mdiWeatherNight);
 </script>
 
 <div class="mt-16 rounded-t-3xl bg-dark/10 p-8">
@@ -135,14 +115,7 @@
 			<VStack class="text-center">
 				<Text size="large">This project is available under GNU AGPL v3 license.</Text>
 				<Text color="muted" variant="italic">Privacy should not be a luxury</Text>
-				<IconButton
-					size="large"
-					shape="round"
-					color="secondary"
-					variant="ghost"
-					icon={themeIcon}
-					onclick={handleToggleTheme}
-				/>
+				<ThemeSwitcher color="secondary" size="large" />
 			</VStack>
 		</Stack>
 	</Container>

--- a/src/lib/components/AppShell/AppShellSidebar.svelte
+++ b/src/lib/components/AppShell/AppShellSidebar.svelte
@@ -34,6 +34,7 @@
 		color={hidden ? 'primary' : 'secondary'}
 		variant="filled"
 		class="absolute bottom-2 right-4 m-2 opacity-100 md:hidden"
+		aria-label="Menu"
 	/>
 	<Scrollable
 		class={cleanClass(

--- a/src/lib/components/Card/Card.svelte
+++ b/src/lib/components/Card/Card.svelte
@@ -114,6 +114,7 @@
 					variant="ghost"
 					shape="round"
 					size="large"
+					aria-label="Expand"
 				/>
 			</div>
 		</button>

--- a/src/lib/components/CloseButton/CloseButton.svelte
+++ b/src/lib/components/CloseButton/CloseButton.svelte
@@ -19,5 +19,5 @@
 	{variant}
 	{size}
 	color="secondary"
-	title={t('close', translations)}
+	aria-label={t('close', translations)}
 />

--- a/src/lib/components/Form/PasswordInput.svelte
+++ b/src/lib/components/Form/PasswordInput.svelte
@@ -27,6 +27,7 @@
 				icon={isVisible ? mdiEyeOffOutline : mdiEyeOutline}
 				onclick={() => (isVisible = !isVisible)}
 				title={isVisible ? t('hidePassword', translations) : t('showPassword', translations)}
+				aria-label={t('showPassword', translations)}
 			/>
 		{/if}
 	{/snippet}

--- a/src/lib/components/IconButton/IconButton.svelte
+++ b/src/lib/components/IconButton/IconButton.svelte
@@ -3,9 +3,18 @@
 	import Icon from '$lib/components/Icon/Icon.svelte';
 	import type { IconButtonProps } from '$lib/types.js';
 
-	const { icon, flipped, flopped, ...buttonProps }: IconButtonProps = $props();
+	const {
+		icon,
+		flipped,
+		flopped,
+		title,
+		'aria-label': ariaLabel,
+		...buttonProps
+	}: IconButtonProps = $props();
+
+	const buttonTitle = title || ariaLabel;
 </script>
 
-<Button icon {...buttonProps}>
-	<Icon {icon} {flipped} {flopped} size="45%" />
+<Button icon {...buttonProps} title={buttonTitle} aria-label={ariaLabel}>
+	<Icon {icon} {flipped} {flopped} size="45%" aria-hidden />
 </Button>

--- a/src/lib/components/ThemeSwitcher/ThemeSwitcher.svelte
+++ b/src/lib/components/ThemeSwitcher/ThemeSwitcher.svelte
@@ -17,7 +17,7 @@
 		class?: string;
 		color?: Color;
 		variant?: Variants;
-		translations?: TranslationProps<'dark_theme'>;
+		translations?: TranslationProps<'darkTheme'>;
 		onChange?: (theme: Theme) => void;
 	};
 
@@ -46,7 +46,7 @@
 	icon={themeIcon}
 	onclick={handleToggleTheme}
 	class={cleanClass(className)}
-	aria-label={t('dark_theme', translations)}
+	aria-label={t('darkTheme', translations)}
 	role="switch"
 	aria-checked={theme.value === Theme.Dark}
 />

--- a/src/lib/components/ThemeSwitcher/ThemeSwitcher.svelte
+++ b/src/lib/components/ThemeSwitcher/ThemeSwitcher.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	import IconButton from '$lib/components/IconButton/IconButton.svelte';
 	import { theme } from '$lib/services/theme.svelte.js';
-	import { Theme, type Color, type Size, type Variants } from '$lib/types.js';
+	import { t } from '$lib/services/translation.svelte.js';
+	import {
+		Theme,
+		type Color,
+		type Size,
+		type TranslationProps,
+		type Variants,
+	} from '$lib/types.js';
 	import { cleanClass } from '$lib/utils.js';
 	import { mdiWeatherNight, mdiWeatherSunny } from '@mdi/js';
 
@@ -10,6 +17,7 @@
 		class?: string;
 		color?: Color;
 		variant?: Variants;
+		translations?: TranslationProps<'dark_theme'>;
 		onChange?: (theme: Theme) => void;
 	};
 
@@ -18,6 +26,7 @@
 		variant = 'ghost',
 		size,
 		class: className,
+		translations,
 		onChange,
 	}: Props = $props();
 
@@ -37,4 +46,7 @@
 	icon={themeIcon}
 	onclick={handleToggleTheme}
 	class={cleanClass(className)}
+	aria-label={t('dark_theme', translations)}
+	role="switch"
+	aria-checked={theme.value === Theme.Dark}
 />

--- a/src/lib/internal/Select.svelte
+++ b/src/lib/internal/Select.svelte
@@ -107,6 +107,7 @@
 							class="m-1"
 							icon={mdiUnfoldMoreHorizontal}
 							{disabled}
+							aria-label="Expand"
 						/>
 					{/snippet}
 				</Input>

--- a/src/lib/services/translation.svelte.ts
+++ b/src/lib/services/translation.svelte.ts
@@ -4,7 +4,7 @@ const defaultTranslations = {
 	close: 'Close',
 	showPassword: 'Show password',
 	hidePassword: 'Hide password',
-	dark_theme: 'Toggle dark theme',
+	darkTheme: 'Toggle dark theme',
 };
 
 export type Translations = typeof defaultTranslations;

--- a/src/lib/services/translation.svelte.ts
+++ b/src/lib/services/translation.svelte.ts
@@ -4,6 +4,7 @@ const defaultTranslations = {
 	close: 'Close',
 	showPassword: 'Show password',
 	hidePassword: 'Hide password',
+	dark_theme: 'Toggle dark theme',
 };
 
 export type Translations = typeof defaultTranslations;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,7 @@ export type IconButtonProps = ButtonBase & {
 	icon: string;
 	flipped?: boolean;
 	flopped?: boolean;
+	'aria-label': string;
 } & ButtonOrAnchor;
 
 type StackBaseProps = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,4 +13,4 @@ export const cleanClass = (...classNames: unknown[]) => {
 export const withPrefix = (key: string) => `immich-ui-${key}`;
 
 let _count = 0;
-export const generateId = (): string => `id-${_count++}`;
+export const generateId = (): string => `ui-id-${_count++}`;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,22 +7,16 @@
 		AppShell,
 		AppShellHeader,
 		AppShellSidebar,
-		IconButton,
 		NavbarGroup,
 		NavbarItem,
 		syncToDom,
 		theme,
-		Theme,
 	} from '@immich/ui';
-	import { mdiHome, mdiWeatherNight, mdiWeatherSunny } from '@mdi/js';
+	import { mdiHome } from '@mdi/js';
 	import '../app.css';
+	import ThemeSwitcher from '$lib/components/ThemeSwitcher/ThemeSwitcher.svelte';
 
 	let { children } = $props();
-
-	const handleToggleTheme = () =>
-		(theme.value = theme.value === Theme.Dark ? Theme.Light : Theme.Dark);
-
-	const themeIcon = $derived(theme.value === Theme.Light ? mdiWeatherSunny : mdiWeatherNight);
 
 	$effect(() => {
 		syncToDom();
@@ -32,14 +26,7 @@
 <AppShell>
 	<AppShellHeader>
 		<Navbar theme={theme.value}>
-			<IconButton
-				size="giant"
-				shape="round"
-				color="primary"
-				variant="ghost"
-				icon={themeIcon}
-				onclick={handleToggleTheme}
-			/>
+			<ThemeSwitcher size="giant" />
 		</Navbar>
 	</AppShellHeader>
 

--- a/src/routes/components/icon-button/BasicExample.svelte
+++ b/src/routes/components/icon-button/BasicExample.svelte
@@ -4,5 +4,5 @@
 </script>
 
 <HStack wrap>
-	<IconButton icon={mdiMagnify}>Click me!</IconButton>
+	<IconButton icon={mdiMagnify} aria-label="Click me!" />
 </HStack>

--- a/src/routes/components/icon-button/ColorExample.svelte
+++ b/src/routes/components/icon-button/ColorExample.svelte
@@ -6,10 +6,10 @@
 </script>
 
 <HStack wrap>
-	<IconButton {icon} color="primary">Primary</IconButton>
-	<IconButton {icon} color="secondary">Secondary</IconButton>
-	<IconButton {icon} color="success">Success</IconButton>
-	<IconButton {icon} color="info">Info</IconButton>
-	<IconButton {icon} color="warning">Warning</IconButton>
-	<IconButton {icon} color="danger">Danger</IconButton>
+	<IconButton {icon} color="primary" aria-label="Primary" />
+	<IconButton {icon} color="secondary" aria-label="Secondary" />
+	<IconButton {icon} color="success" aria-label="Success" />
+	<IconButton {icon} color="info" aria-label="Info" />
+	<IconButton {icon} color="warning" aria-label="Warning" />
+	<IconButton {icon} color="danger" aria-label="Danger" />
 </HStack>

--- a/src/routes/components/icon-button/DisabledExample.svelte
+++ b/src/routes/components/icon-button/DisabledExample.svelte
@@ -6,10 +6,10 @@
 </script>
 
 <HStack wrap>
-	<IconButton {icon} disabled color="primary">Primary</IconButton>
-	<IconButton {icon} disabled color="secondary">Secondary</IconButton>
-	<IconButton {icon} disabled color="success">Success</IconButton>
-	<IconButton {icon} disabled color="info">Info</IconButton>
-	<IconButton {icon} disabled color="warning">Warning</IconButton>
-	<IconButton {icon} disabled color="danger">Danger</IconButton>
+	<IconButton {icon} disabled color="primary" aria-label="Primary" />
+	<IconButton {icon} disabled color="secondary" aria-label="Secondary" />
+	<IconButton {icon} disabled color="success" aria-label="Success" />
+	<IconButton {icon} disabled color="info" aria-label="Info" />
+	<IconButton {icon} disabled color="warning" aria-label="Warning" />
+	<IconButton {icon} disabled color="danger" aria-label="Danger" />
 </HStack>

--- a/src/routes/components/icon-button/GhostExample.svelte
+++ b/src/routes/components/icon-button/GhostExample.svelte
@@ -6,10 +6,10 @@
 </script>
 
 <HStack wrap>
-	<IconButton {icon} variant="ghost" color="primary">Primary</IconButton>
-	<IconButton {icon} variant="ghost" color="secondary">Secondary</IconButton>
-	<IconButton {icon} variant="ghost" color="success">Success</IconButton>
-	<IconButton {icon} variant="ghost" color="info">Info</IconButton>
-	<IconButton {icon} variant="ghost" color="warning">Warning</IconButton>
-	<IconButton {icon} variant="ghost" color="danger">Danger</IconButton>
+	<IconButton {icon} variant="ghost" color="primary" aria-label="Primary" />
+	<IconButton {icon} variant="ghost" color="secondary" aria-label="Secondary" />
+	<IconButton {icon} variant="ghost" color="success" aria-label="Success" />
+	<IconButton {icon} variant="ghost" color="info" aria-label="Info" />
+	<IconButton {icon} variant="ghost" color="warning" aria-label="Warning" />
+	<IconButton {icon} variant="ghost" color="danger" aria-label="Danger" />
 </HStack>

--- a/src/routes/components/icon-button/OutlineExample.svelte
+++ b/src/routes/components/icon-button/OutlineExample.svelte
@@ -6,10 +6,10 @@
 </script>
 
 <HStack wrap>
-	<IconButton {icon} variant="outline" color="primary">Primary</IconButton>
-	<IconButton {icon} variant="outline" color="secondary">Secondary</IconButton>
-	<IconButton {icon} variant="outline" color="success">Success</IconButton>
-	<IconButton {icon} variant="outline" color="info">Info</IconButton>
-	<IconButton {icon} variant="outline" color="warning">Warning</IconButton>
-	<IconButton {icon} variant="outline" color="danger">Danger</IconButton>
+	<IconButton {icon} variant="outline" color="primary" aria-label="Primary" />
+	<IconButton {icon} variant="outline" color="secondary" aria-label="Secondary" />
+	<IconButton {icon} variant="outline" color="success" aria-label="Success" />
+	<IconButton {icon} variant="outline" color="info" aria-label="Info" />
+	<IconButton {icon} variant="outline" color="warning" aria-label="Warning" />
+	<IconButton {icon} variant="outline" color="danger" aria-label="Danger" />
 </HStack>

--- a/src/routes/components/icon-button/ShapeExample.svelte
+++ b/src/routes/components/icon-button/ShapeExample.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <HStack wrap>
-	<IconButton {icon} shape="rectangle">Rectangle</IconButton>
-	<IconButton {icon} shape="semi-round">Semi-Round</IconButton>
-	<IconButton {icon} shape="round">Round</IconButton>
+	<IconButton {icon} shape="rectangle" aria-label="Rectangle" />
+	<IconButton {icon} shape="semi-round" aria-label="Semi-Round" />
+	<IconButton {icon} shape="round" aria-label="Round" />
 </HStack>

--- a/src/routes/components/icon-button/SizeExample.svelte
+++ b/src/routes/components/icon-button/SizeExample.svelte
@@ -9,57 +9,57 @@
 	<Stack>
 		<Heading size="tiny">Semi-Round</Heading>
 		<div>
-			<IconButton {icon} size="tiny">Tiny</IconButton>
+			<IconButton {icon} size="tiny" aria-label="Tiny" />
 		</div>
 		<div>
-			<IconButton {icon} size="small">Small</IconButton>
+			<IconButton {icon} size="small" aria-label="Small" />
 		</div>
 		<div>
-			<IconButton {icon} size="medium">Medium</IconButton>
+			<IconButton {icon} size="medium" aria-label="Medium" />
 		</div>
 		<div>
-			<IconButton {icon} size="large">Large</IconButton>
+			<IconButton {icon} size="large" aria-label="Large" />
 		</div>
 		<div>
-			<IconButton {icon} size="giant">Giant</IconButton>
+			<IconButton {icon} size="giant" aria-label="Giant" />
 		</div>
 	</Stack>
 
 	<Stack>
 		<Heading size="tiny">Round</Heading>
 		<div>
-			<IconButton {icon} shape="round" size="tiny">Tiny</IconButton>
+			<IconButton {icon} shape="round" size="tiny" aria-label="Tiny" />
 		</div>
 		<div>
-			<IconButton {icon} shape="round" size="small">Small</IconButton>
+			<IconButton {icon} shape="round" size="small" aria-label="Small" />
 		</div>
 		<div>
-			<IconButton {icon} shape="round" size="medium">Medium</IconButton>
+			<IconButton {icon} shape="round" size="medium" aria-label="Medium" />
 		</div>
 		<div>
-			<IconButton {icon} shape="round" size="large">Large</IconButton>
+			<IconButton {icon} shape="round" size="large" aria-label="Large" />
 		</div>
 		<div>
-			<IconButton {icon} shape="round" size="giant">Giant</IconButton>
+			<IconButton {icon} shape="round" size="giant" aria-label="Giant" />
 		</div>
 	</Stack>
 
 	<Stack>
 		<Heading size="tiny">Rectangle</Heading>
 		<div>
-			<IconButton {icon} shape="rectangle" size="tiny">Tiny</IconButton>
+			<IconButton {icon} shape="rectangle" size="tiny" aria-label="Tiny" />
 		</div>
 		<div>
-			<IconButton {icon} shape="rectangle" size="small">Small</IconButton>
+			<IconButton {icon} shape="rectangle" size="small" aria-label="Small" />
 		</div>
 		<div>
-			<IconButton {icon} shape="rectangle" size="medium">Medium</IconButton>
+			<IconButton {icon} shape="rectangle" size="medium" aria-label="Medium" />
 		</div>
 		<div>
-			<IconButton {icon} shape="rectangle" size="large">Large</IconButton>
+			<IconButton {icon} shape="rectangle" size="large" aria-label="Large" />
 		</div>
 		<div>
-			<IconButton {icon} shape="rectangle" size="giant">Giant</IconButton>
+			<IconButton {icon} shape="rectangle" size="giant" aria-label="Giant" />
 		</div>
 	</Stack>
 </HStack>


### PR DESCRIPTION
Add a required `aria-label` prop to the IconButton component, to guarantee that it always has an accessible label. 

**Also in this change:**

- making the unique ID generator not collide with the existing ID generator in the Immich web app
- replace custom theme buttons with the `ThemeSwitcher` component
- add aria roles to the theme switcher to make it more helpful for screen readers