### PR TITLE
feat: theme switcher options

### DIFF
--- a/src/docs/components/Footer.svelte
+++ b/src/docs/components/Footer.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
-	import ThemeSwitcher from '$lib/components/ThemeSwitcher/ThemeSwitcher.svelte';
-	import { Card, Container, Heading, HStack, Icon, Link, Stack, Text, VStack } from '@immich/ui';
+	import {
+		Card,
+		Container,
+		Heading,
+		HStack,
+		Icon,
+		Link,
+		Stack,
+		Text,
+		ThemeSwitcher,
+		VStack,
+	} from '@immich/ui';
 	import {
 		mdiAndroid,
 		mdiApple,

--- a/src/lib/components/ThemeSwitcher/ThemeSwitcher.svelte
+++ b/src/lib/components/ThemeSwitcher/ThemeSwitcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import IconButton from '$lib/components/IconButton/IconButton.svelte';
-	import { theme } from '$lib/services/theme.svelte.js';
+	import { onThemeChange, theme } from '$lib/services/theme.svelte.js';
 	import { t } from '$lib/services/translation.svelte.js';
 	import {
 		Theme,
@@ -33,6 +33,7 @@
 	const handleToggleTheme = () => {
 		theme.value = theme.value === Theme.Dark ? Theme.Light : Theme.Dark;
 		onChange?.(theme.value);
+		onThemeChange();
 	};
 
 	const themeIcon = $derived(theme.value === Theme.Light ? mdiWeatherSunny : mdiWeatherNight);

--- a/src/lib/services/preference.svelte.ts
+++ b/src/lib/services/preference.svelte.ts
@@ -1,0 +1,51 @@
+import { browser } from '$app/environment';
+
+const asKey = (key: string) => `immich-ui-${key}`;
+
+const readPreference = <T>(key: string, defaults: T) => {
+	if (!browser || !window?.localStorage) {
+		throw new Error('Local storage is not available');
+	}
+
+	const text = window.localStorage.getItem(asKey(key));
+	const stored = text ? (JSON.parse(text) as T) : {};
+
+	return { ...defaults, ...stored };
+};
+
+const writePreference = <T>(key: string, value: T) => {
+	if (!browser || !window.localStorage) {
+		throw new Error('Local storage is not available');
+	}
+	const text = JSON.stringify(value);
+	window.localStorage.setItem(asKey(key), text);
+};
+
+type PreferenceOptions<T> = {
+	key: string;
+	defaults: T;
+	onReadError?: (error: unknown) => void;
+	onWriteError?: (error: unknown) => void;
+};
+export const preference = <T>(options: PreferenceOptions<T>) => {
+	const { key, defaults, onReadError, onWriteError } = options;
+
+	let initialValue = defaults;
+	try {
+		initialValue = readPreference<T>(key, defaults);
+	} catch (error) {
+		onReadError?.(error);
+	}
+
+	const state = $state<T>(initialValue);
+
+	const sync = () => {
+		try {
+			writePreference(key, state);
+		} catch (error) {
+			onWriteError?.(error);
+		}
+	};
+
+	return { state, sync };
+};

--- a/src/lib/services/theme.svelte.ts
+++ b/src/lib/services/theme.svelte.ts
@@ -1,16 +1,73 @@
+import { browser } from '$app/environment';
+import { preference } from '$lib/services/preference.svelte.js';
 import { Theme } from '$lib/types.js';
 
-export const theme = $state<{ value: Theme }>({ value: Theme.Dark });
+export type ThemeOptions = {
+	lightClass?: string;
+	darkClass?: string;
+	selector?: string;
+};
 
-export const syncToDom = () => {
+const defaultOptions: ThemeOptions = {
+	darkClass: 'dark',
+	selector: 'body',
+};
+
+let options = $state<ThemeOptions>(defaultOptions);
+
+export const setThemeOptions = (newOptions: ThemeOptions) =>
+	(options = { ...defaultOptions, ...newOptions });
+
+type ThemePreference = { value: Theme };
+const defaultTheme: ThemePreference = { value: Theme.Dark };
+const { state, sync: syncToLocalStorage } = preference<ThemePreference>({
+	key: 'theme',
+	defaults: defaultTheme,
+	onReadError: (error) => console.log(`Preference read error: ${error}`),
+	onWriteError: (error) => console.log(`Preference write error: ${error}`),
+});
+
+export const theme = state;
+
+export const onThemeChange = () => {
+	syncToDom();
+	syncToLocalStorage();
+};
+
+const syncToDom = () => {
+	const { lightClass, darkClass, selector } = options;
+	if (!browser || !selector) {
+		return;
+	}
+
+	const element = document.querySelector(selector);
+	if (!element) {
+		return;
+	}
+
 	switch (theme.value) {
 		case Theme.Dark: {
-			document.body.classList.add('dark');
+			if (lightClass) {
+				element.classList.remove(lightClass);
+			}
+
+			if (darkClass) {
+				element.classList.add(darkClass);
+			}
 			break;
 		}
 
-		default: {
-			document.body.classList.remove('dark');
+		case Theme.Light: {
+			if (lightClass) {
+				element.classList.add(lightClass);
+			}
+
+			if (darkClass) {
+				element.classList.remove(darkClass);
+			}
+			break;
 		}
 	}
 };
+
+syncToDom();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,18 +9,13 @@
 		AppShellSidebar,
 		NavbarGroup,
 		NavbarItem,
-		syncToDom,
 		theme,
+		ThemeSwitcher,
 	} from '@immich/ui';
 	import { mdiHome } from '@mdi/js';
 	import '../app.css';
-	import ThemeSwitcher from '$lib/components/ThemeSwitcher/ThemeSwitcher.svelte';
 
 	let { children } = $props();
-
-	$effect(() => {
-		syncToDom();
-	});
 </script>
 
 <AppShell>


### PR DESCRIPTION
- Fix `ThemeSwitcher` import
- Load initial theme value from local storage, if present
- Sync theme changes to local storage and dom
- Add an option to specify both light and dark theme class names
- Add an option to specify the element selector (eg `html` or `body`)