### PR TITLE
fix: better contrast on disabled input component in light mode

### DIFF
--- a/src/lib/components/Form/Input.svelte
+++ b/src/lib/components/Form/Input.svelte
@@ -19,7 +19,7 @@
 		$derived(getFieldContext());
 
 	const inputStyles = tv({
-		base: 'w-full bg-gray-200 outline-none disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-400 aria-readonly:text-dark/50 dark:bg-gray-600 dark:disabled:bg-gray-800 dark:disabled:text-gray-200 dark:aria-readonly:text-dark/75' ,
+		base: 'w-full bg-gray-200 outline-none disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-400 aria-readonly:text-dark/50 dark:bg-gray-600 dark:disabled:bg-gray-800 dark:disabled:text-gray-200 dark:aria-readonly:text-dark/75',
 		variants: {
 			shape: {
 				rectangle: 'rounded-none',


### PR DESCRIPTION
This issue addresses the lack of contrast found on disabled Input components in light mode.

<details><summary><h2>Screenshots</h2></summary>

## Before

![image](https://github.com/user-attachments/assets/d8accd81-1bda-4751-8e2f-308c4f7d30e0)

## After 

![image](https://github.com/user-attachments/assets/2a243da1-c1f9-438c-8109-8fd62668b8ab)

</details>

see immich-app/immich#16368

Related to PR immich-app/immich#16382