### PR TITLE
fix: custom webkit scrollbars

### DIFF
--- a/src/lib/components/Scrollable/Scrollable.svelte
+++ b/src/lib/components/Scrollable/Scrollable.svelte
@@ -29,23 +29,39 @@
 	.immich-scrollbar::-webkit-scrollbar {
 		width: 8px;
 		height: 8px;
+		visibility: hidden;
 	}
-
 	/* Track */
 	.immich-scrollbar::-webkit-scrollbar-track {
 		background: #f1f1f1;
 		border-radius: 16px;
+		visibility: hidden;
 	}
 
 	/* Handle */
 	.immich-scrollbar::-webkit-scrollbar-thumb {
 		background: rgba(85, 86, 87, 0.408);
 		border-radius: 16px;
+		visibility: hidden;
 	}
 
 	/* Handle on hover */
 	.immich-scrollbar::-webkit-scrollbar-thumb:hover {
 		background: #4250afad;
 		border-radius: 16px;
+	}
+
+	/*
+		* Show scrollbar elements when hovering or actively scrolling
+		* Applies to the main scrollbar, track, and thumb components
+		* Changes visibility from hidden to visible on user interaction
+	*/
+	.immich-scrollbar:hover::-webkit-scrollbar,
+	.immich-scrollbar:active::-webkit-scrollbar,
+	.immich-scrollbar:hover::-webkit-scrollbar-track,
+	.immich-scrollbar:active::-webkit-scrollbar-track,
+	.immich-scrollbar:hover::-webkit-scrollbar-thumb,
+	.immich-scrollbar:active::-webkit-scrollbar-thumb {
+		visibility: visible;
 	}
 </style>


### PR DESCRIPTION
The aim of the PR is to align the behaviour of the custom webkit scrollbars to that seen on MacOS i.e. hidden when not active.

Before (always visible)
![localhost_5173_](https://github.com/user-attachments/assets/4f180ddf-c8e4-4986-8f82-244330ad40ff)

After (viable on hover)
![change](https://github.com/user-attachments/assets/cc7544b2-2bd1-4a09-9ea0-4b783382d279)

Tested on Chrome (MacOs and Windows)
