### PR TITLE
chore: modal tweaks

### DIFF
--- a/src/lib/components/Modal/Modal.svelte
+++ b/src/lib/components/Modal/Modal.svelte
@@ -37,7 +37,7 @@
 	}: Props = $props();
 
 	const modalStyles = tv({
-		base: 'flex rounded-none border border-subtle bg-subtle sm:rounded-2xl',
+		base: 'flex rounded-none border-none bg-light dark:bg-subtle sm:rounded-2xl',
 		variants: {
 			size: {
 				tiny: 'h-full sm:h-min md:max-w-sm',
@@ -78,7 +78,7 @@
 							{:else if icon}
 								<Logo variant="icon" size="tiny" />
 							{/if}
-							<CardTitle tag="h1" class="grow">{title}</CardTitle>
+							<CardTitle tag="p" class="grow">{title}</CardTitle>
 							<Dialog.Close>
 								<CloseButton onclick={() => onChange(false)} class="-me-2" />
 							</Dialog.Close>


### PR DESCRIPTION
Use white instead of almost white for light-mode modals

Before
![image](https://github.com/user-attachments/assets/e5f281df-1eaa-4a12-a5b3-cec14bce12e1)

After
![image](https://github.com/user-attachments/assets/03404172-0655-44fd-b4a1-0e2947639bd8)