### PR TITLE
fix: event propagation issue

### DIFF
--- a/src/lib/components/Modal/Modal.svelte
+++ b/src/lib/components/Modal/Modal.svelte
@@ -61,6 +61,16 @@
 	};
 </script>
 
+<svelte:document
+	onkeydown={(e) => {
+		if (e.key === 'Escape' && open) {
+			// Stop propagation to ensure modals close before immich-web takes over
+			e.stopPropagation();
+			open = false;
+			onClose?.();
+		}
+	}}
+/>
 <Dialog.Root {open} onOpenChange={onChange}>
 	<Dialog.Portal>
 		<Dialog.Overlay class="absolute start-0 top-0 flex h-dvh w-screen bg-black/30" />

--- a/src/lib/components/Modal/Modal.svelte
+++ b/src/lib/components/Modal/Modal.svelte
@@ -61,16 +61,6 @@
 	};
 </script>
 
-<!-- <svelte:document
-	onkeydown={(e) => {
-		if (e.key === 'Escape' && open) {
-			// Stop propagation to ensure modals close before immich-web takes over
-			e.stopPropagation();
-			open = false;
-			onClose?.();
-		}
-	}}
-/> -->
 <Dialog.Root {open} onOpenChange={onChange}>
 	<Dialog.Portal>
 		<Dialog.Overlay class="absolute start-0 top-0 flex h-dvh w-screen bg-black/30" />

--- a/src/lib/components/Modal/Modal.svelte
+++ b/src/lib/components/Modal/Modal.svelte
@@ -61,7 +61,7 @@
 	};
 </script>
 
-<svelte:document
+<!-- <svelte:document
 	onkeydown={(e) => {
 		if (e.key === 'Escape' && open) {
 			// Stop propagation to ensure modals close before immich-web takes over
@@ -70,11 +70,19 @@
 			onClose?.();
 		}
 	}}
-/>
+/> -->
 <Dialog.Root {open} onOpenChange={onChange}>
 	<Dialog.Portal>
 		<Dialog.Overlay class="absolute start-0 top-0 flex h-dvh w-screen bg-black/30" />
 		<Dialog.Content
+			onkeydown={(e) => {
+				if (e.key === 'Escape' && open) {
+					// Stop propagation to ensure modals close before immich-web takes over
+					e.stopPropagation();
+					open = false;
+					onClose?.();
+				}
+			}}
 			class={cleanClass(
 				'absolute start-0 top-0 flex h-dvh w-screen items-center justify-center overflow-hidden sm:p-4',
 			)}


### PR DESCRIPTION
# Description
This fixes the issue where immich-web handles escape key events before the modals from the ui lib do, resulting in unexpected behaviours.

The first attempt doest not work:

Moving the escape event listeners in immich-web to `svelte:document` and using the `onEscapeKeydown` callback on `Dialog.Content`: No luck, the document listener fires first, the callback doesn't get called at all.
```svelte
// In ui: Modal.svelte
<Dialog.Content
	onEscapeKeydown={(e) => { // Never gets called at all !
		e.stopPropagation();
		open = false;
		onClose?.();
	}}
>

// In immich/web: close-action.svelte
<svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: onClose }} />
```

Currently there are 2 approaches that do work:
- Add a `svelte.document` listener inside of the `Modal.svelte` which catches the event. This requires no changes in the main immich project
```svelte
<svelte:document
	onkeydown={(e) => {
		if (e.key === 'Escape' && open) {
			// Stop propagation to ensure modals close before immich-web takes over
			e.stopPropagation();
			open = false;
			onClose?.();
		}
	}}
/> -->
<Dialog.Root {open} onOpenChange={onChange}>...</Dialog.Root>
```
- Add a `onkeydown` listener on the `Dialog.Content` component which captures escape keydown events *and* change the listeners in main immich project from `svelte.window` to `svelte.document`
```svelte
// In ui: Modal.svelte
<Dialog.Content
	onkeydown={(e) => {
		if (e.key === 'Escape' && open) {
			// Stop propagation to ensure modals close before immich-web takes over
			e.stopPropagation();
			open = false;
			onClose?.();
		}
	}}
>

// In immich/web: close-action.svelte
<svelte:document use:shortcut={{ shortcut: { key: 'Escape' }, onShortcut: onClose }} />
```

@danieldietzler suggested to first upgrade `bits-ui` and check again if the first approach still doesn't work, because it is quite confusing :D

Hence #177 