### PR TITLE
fix: button titles not updating when title or aria-label changes

### DIFF
--- a/src/lib/components/IconButton/IconButton.svelte
+++ b/src/lib/components/IconButton/IconButton.svelte
@@ -12,7 +12,7 @@
 		...buttonProps
 	}: IconButtonProps = $props();
 
-	const buttonTitle = title || ariaLabel;
+	const buttonTitle = $derived(title || ariaLabel);
 </script>
 
 <Button icon {...buttonProps} title={buttonTitle} aria-label={ariaLabel}>


### PR DESCRIPTION
When you update aria-label or title, the button title will not change since it is not marked as `$derived`.