### PR TITLE
fix: memory leak

### DIFF
--- a/src/lib/components/Modal/Modal.svelte
+++ b/src/lib/components/Modal/Modal.svelte
@@ -88,7 +88,7 @@
 							{/if}
 							<CardTitle tag="p" class="text-dark/90 grow text-lg font-semibold">{title}</CardTitle>
 							<Dialog.Close>
-								<CloseButton onclick={() => onChange(false)} class="-me-2" />
+								<CloseButton class="-me-2" />
 							</Dialog.Close>
 						</div>
 					</CardHeader>


### PR DESCRIPTION
Fixes immich-app/immich#18615.
In library bits-ui, `<Dialog.Close>` will invoke `onClose()`.
So `onclick()` in `CloseButton` is not necessary. Otherwise, for a modal component, `onClose()` will be invoked twice.
It causes memory leak.
![image](https://github.com/user-attachments/assets/61127a8b-b209-4f7f-8065-e6e79ef02cc8)
