### PR TITLE
fix: modal race condition

### DIFF
--- a/src/lib/services/modalManager.svelte.ts
+++ b/src/lib/services/modalManager.svelte.ts
@@ -31,6 +31,7 @@ class ModalManager {
 		const deferred = new Promise<StripValueIfOptional<K>>((resolve) => {
 			onClose = async (...args: [StripValueIfOptional<K>]) => {
 				await unmount(modal);
+				// make sure bits-ui clean up finishes before resolving
 				setTimeout(() => resolve(args?.[0]), 0);
 			};
 

--- a/src/lib/services/modalManager.svelte.ts
+++ b/src/lib/services/modalManager.svelte.ts
@@ -31,7 +31,7 @@ class ModalManager {
 		const deferred = new Promise<StripValueIfOptional<K>>((resolve) => {
 			onClose = async (...args: [StripValueIfOptional<K>]) => {
 				await unmount(modal);
-                setTimeout(() => resolve(args?.[0]), 0);
+				setTimeout(() => resolve(args?.[0]), 0);
 			};
 
 			modal = mount(Component, {

--- a/src/lib/services/modalManager.svelte.ts
+++ b/src/lib/services/modalManager.svelte.ts
@@ -31,7 +31,7 @@ class ModalManager {
 		const deferred = new Promise<StripValueIfOptional<K>>((resolve) => {
 			onClose = async (...args: [StripValueIfOptional<K>]) => {
 				await unmount(modal);
-				resolve(args?.[0]);
+                setTimeout(() => resolve(args?.[0]), 0);
 			};
 
 			modal = mount(Component, {


### PR DESCRIPTION
Further fix for immich-app/immich#18615.

In fix #196, memory leak in modal was fixed. But the issue immich-app/immich#18615 is still exists during my test. This fix is thorough, and here is the root cause for this issue.

In library `bits-ui`, there is a property named `preventScroll` in `Dialog.Content`.
https://www.bits-ui.com/docs/components/combobox#scroll-lock
After reading the source, I know this property is used to prevent the document from scrolling. The default value is true.
It will set `pointerEvents: none` and `overflow: hidden` to the document.

https://github.com/huntabyte/bits-ui/blob/ddcce0ae531514cbdb609c68e7c8c446eba9c04f/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.ts#L81

But the key point is that it is in the `nextTick()`, so if you move from one modal to another modal, this will be invoked after the modal is created. So the fix in immich-app/immich#19463 is suitable. Using `setTimeout(func, 0)` to enforce to execute `func` in the next event loop can invoke `nextTick()` before the creation of the second modal.

There is another fix what you can see in PR. Because we use `Dialog.Content` and `Dialog.Overlay` with `w-full` and `h-full` property, the document is under the modal entirely, so enabling the scroll cannot cause any scroll actually. I think it is more reasonable than immich-app/immich#19463.

Thanks to @jinxuan-owyong with great explain in https://github.com/immich-app/immich/issues/18615#issuecomment-2924608577.