### PR TITLE
fix: change immich dark color in light mode to be darker

### DIFF
--- a/src/lib/theme/default.css
+++ b/src/lib/theme/default.css
@@ -18,7 +18,7 @@
 	.light {
 		/* light */
 		--immich-ui-primary: 66 80 175;
-		--immich-ui-dark: 58 58 58;
+		--immich-ui-dark: 20 22 26;
 		--immich-ui-light: 255 255 255;
 		--immich-ui-success: 16 188 99;
 		--immich-ui-danger: 200 60 60;


### PR DESCRIPTION
This changes `immich-ui-dark` in light theme to be darker, so it looks black rather than grayed out. I went for a similar distance from black as `immich-ui-dark` in dark theme is from white.