### PR TITLE
fix: input spacing

### DIFF
--- a/src/lib/components/Form/Input.svelte
+++ b/src/lib/components/Form/Input.svelte
@@ -97,7 +97,7 @@
 		<Text color="secondary" size="small" id={descriptionId}>{description}</Text>
 	{/if}
 
-	<div class={cleanClass('relative w-full', label && 'mt-1.5')}>
+	<div class="relative w-full">
 		{#if leadingIcon}
 			<div tabindex="-1" class={iconStyles({ size })}>
 				{#if leadingIcon}


### PR DESCRIPTION
This already has gap-1, and no other input types have this extra padding.