### PR TITLE
feat: icon like

### DIFF
--- a/src/lib/components/Form/Input.svelte
+++ b/src/lib/components/Form/Input.svelte
@@ -3,7 +3,7 @@
 	import Label from '$lib/components/Label/Label.svelte';
 	import Text from '$lib/components/Text/Text.svelte';
 	import type { InputProps } from '$lib/types.js';
-	import { cleanClass, generateId } from '$lib/utils.js';
+	import { cleanClass, generateId, isIconLike } from '$lib/utils.js';
 	import Icon from '$lib/components/Icon/Icon.svelte';
 	import { tv } from 'tailwind-variants';
 
@@ -102,7 +102,7 @@
 		{#if leadingIcon}
 			<div tabindex="-1" class={iconStyles({ size })}>
 				{#if leadingIcon}
-					{#if typeof leadingIcon === 'string'}
+					{#if isIconLike(leadingIcon)}
 						<Icon size="60%" icon={leadingIcon} />
 					{:else}
 						{@render leadingIcon()}
@@ -139,7 +139,7 @@
 		{#if trailingIcon}
 			<div tabindex="-1" class={cleanClass(iconStyles({ size }), 'end-0')}>
 				{#if trailingIcon}
-					{#if typeof trailingIcon === 'string'}
+					{#if isIconLike(trailingIcon)}
 						<Icon size="60%" icon={trailingIcon} />
 					{:else}
 						{@render trailingIcon()}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,10 +28,10 @@ export enum Theme {
 
 export type TranslationProps<T extends keyof Translations> = { [K in T]?: string };
 
-type PathLike = { path: string };
+export type IconLike = string | { path: string };
 
 export type IconProps = {
-	icon: string | PathLike;
+	icon: IconLike;
 	title?: string;
 	description?: string;
 	size?: string;
@@ -61,8 +61,8 @@ export type ButtonProps = ButtonBase & {
 	ref?: HTMLElement | null;
 	fullWidth?: boolean;
 	loading?: boolean;
-	leadingIcon?: string;
-	trailingIcon?: string;
+	leadingIcon?: IconLike;
+	trailingIcon?: IconLike;
 } & ButtonOrAnchor;
 
 export type CloseButtonProps = {
@@ -129,8 +129,8 @@ type BaseInputProps = {
 export type InputProps = BaseInputProps & {
 	containerRef?: HTMLElement | null;
 	type?: HTMLInputAttributes['type'];
-	leadingIcon?: string | Snippet;
-	trailingIcon?: string | Snippet;
+	leadingIcon?: IconLike | Snippet;
+	trailingIcon?: IconLike | Snippet;
 };
 
 export type PasswordInputProps = BaseInputProps & {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import type { IconLike } from '$lib/types.js';
 import { twMerge } from 'tailwind-merge';
 
 export const cleanClass = (...classNames: unknown[]) => {
@@ -18,3 +19,7 @@ export const withPrefix = (key: string) => `immich-ui-${key}`;
 
 let _count = 0;
 export const generateId = (): string => `ui-id-${_count++}`;
+
+export const isIconLike = (icon: unknown): icon is IconLike => {
+	return typeof icon === 'string' || !!(icon && typeof icon === 'object' && 'path' in icon);
+};


### PR DESCRIPTION
Support `string | {path: string}` in more places we accept icon paths for use with `simple-icons` and other packages