### PR TITLE
fix: set bootstrap-sha for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "a331426c1842c86110e49c651af65b95dc437baa",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
This should make it stop including any commits before this in the "first" release.