### PR TITLE
chore: toast css nits

### DIFF
--- a/packages/ui/src/lib/components/Toast/ToastContainer.svelte
+++ b/packages/ui/src/lib/components/Toast/ToastContainer.svelte
@@ -29,7 +29,14 @@
       },
 
       border: styleVariants.border,
-      borderColor: styleVariants.borderColor,
+      borderColor: {
+        primary: 'border-primary/25',
+        secondary: 'border-dark/25',
+        success: 'border-success/25',
+        danger: 'border-danger/25',
+        warning: 'border-warning/25',
+        info: 'border-info/25',
+      },
       roundedSize: {
         tiny: 'rounded-lg',
         small: 'rounded-lg',

--- a/packages/ui/src/lib/styles.ts
+++ b/packages/ui/src/lib/styles.ts
@@ -26,12 +26,12 @@ export const styleVariants = {
   },
 
   borderColor: {
-    primary: 'border-primary/25',
-    secondary: 'border-dark/25',
-    success: 'border-success/25',
-    danger: 'border-danger/25',
-    warning: 'border-warning/25',
-    info: 'border-info/25',
+    primary: 'border-primary',
+    secondary: 'border-dark',
+    success: 'border-success',
+    danger: 'border-danger',
+    warning: 'border-warning',
+    info: 'border-info',
   },
 
   fillColor: {


### PR DESCRIPTION
- Make the outline's variant border less intense.
- Distinguish filled and outline variant

| before | after |
| - | - |
|  <img width="335" height="529" alt="image" src="https://github.com/user-attachments/assets/70cca252-cbb6-4c7d-8249-1c26a38662a0" /> | <img width="349" height="529" alt="image" src="https://github.com/user-attachments/assets/16dff22a-6bce-4e69-af5c-1c8c6796f908" />
 