### PR TITLE
feat: system theme

### DIFF
--- a/packages/ui/src/app.html
+++ b/packages/ui/src/app.html
@@ -6,7 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script>
       try {
-        if (JSON.parse(localStorage.getItem('immich-ui-theme')) === 'light') {
+        const preference = JSON.parse(localStorage.getItem('immich-ui-theme'));
+        const prefersDark = globalThis.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (preference === 'light' || (preference !== 'dark' && !prefersDark)) {
           document.documentElement.classList.remove('dark');
           document.documentElement.classList.add('light');
         }

--- a/packages/ui/src/lib/services/theme-manager.svelte.ts
+++ b/packages/ui/src/lib/services/theme-manager.svelte.ts
@@ -1,101 +1,104 @@
 import { browser } from '$app/environment';
 import { PersistedLocalStorage } from '$lib/state/persisted.js';
-import { Theme } from '$lib/types.js';
+import { Theme, ThemePreference } from '$lib/types.js';
+import { MediaQuery } from 'svelte/reactivity';
 
-export type ThemeOptions = {
-  lightClass?: string;
-  darkClass?: string;
-  selector?: string;
-};
-
-const DEFAULT_OPTIONS: ThemeOptions = Object.freeze({
-  lightClass: 'light',
-  darkClass: 'dark',
-  selector: 'html',
-});
+const LIGHT_CLASS = 'light';
+const DARK_CLASS = 'dark';
+const DARK_READER_LOCK_NAME = 'darkreader-lock';
 
 class ThemeManager {
-  #theme = new PersistedLocalStorage<Theme>('immich-ui-theme', Theme.Dark, {
-    upgrade: (value: unknown) => {
-      if (value && typeof value === 'object' && 'value' in value) {
-        value = value.value;
+  #darkModeUser = new MediaQuery('(prefers-color-scheme: dark)');
+  #theme = new PersistedLocalStorage<ThemePreference>('immich-ui-theme', ThemePreference.System, {
+    upgrade: (
+      value:
+        | string // default
+        | { value: string; system?: boolean }, // immich
+    ) => {
+      if (typeof value === 'object' && value.system) {
+        if (value.system) {
+          return ThemePreference.System;
+        }
+
+        if (value.value) {
+          value = value.value;
+        }
       }
 
-      if (value === 'light' || value === 'dark') {
-        return value as Theme;
+      if (typeof value === 'string' && Object.values(ThemePreference).includes(value as ThemePreference)) {
+        return value as ThemePreference;
       }
 
-      return Theme.Dark;
+      return ThemePreference.System;
     },
   });
-  #options = $state<ThemeOptions>({ ...DEFAULT_OPTIONS });
+
+  get prefersDark() {
+    return this.#darkModeUser.current;
+  }
 
   get value() {
-    return this.#theme.current;
+    switch (this.#theme.current) {
+      case ThemePreference.System: {
+        return this.#darkModeUser.current ? Theme.Dark : Theme.Light;
+      }
+
+      case ThemePreference.Light: {
+        return Theme.Light;
+      }
+
+      default: {
+        return Theme.Dark;
+      }
+    }
   }
 
-  initialize(options?: ThemeOptions) {
-    if (options) {
-      this.setOptions(options);
+  constructor() {
+    if (!browser) {
+      return;
     }
 
-    this.#syncToDom();
-  }
-
-  setOptions(newOptions: ThemeOptions) {
-    this.#options = { ...DEFAULT_OPTIONS, ...newOptions };
-    this.#onChange();
+    globalThis
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', () => this.#syncToDom(), { passive: true });
   }
 
   toggle() {
-    this.#theme.current = this.#theme.current === Theme.Dark ? Theme.Light : Theme.Dark;
-    this.#onChange();
+    this.#theme.current = this.value === Theme.Dark ? ThemePreference.Light : ThemePreference.Dark;
+    this.#syncToDom();
   }
 
-  #onChange() {
+  setPreference(preference: ThemePreference) {
+    this.#theme.current = preference;
     this.#syncToDom();
   }
 
   #syncToDom() {
-    const { lightClass, darkClass, selector } = this.#options;
-    if (!browser || !selector) {
+    if (!browser) {
       return;
     }
 
-    const element = document.querySelector(selector);
+    const element = document.querySelector('html');
     if (!element) {
       return;
     }
 
-    switch (this.#theme.current) {
+    switch (this.value) {
       case Theme.Dark: {
-        if (lightClass) {
-          element.classList.remove(lightClass);
-        }
-
-        if (darkClass) {
-          element.classList.add(darkClass);
-        }
-
-        const darkReaderLock = document.createElement('meta');
-        darkReaderLock.name = 'darkreader-lock';
-        document.head.appendChild(darkReaderLock);
-
+        element.classList.remove(LIGHT_CLASS);
+        element.classList.add(DARK_CLASS);
+        const lockRef = document.createElement('meta');
+        lockRef.name = DARK_READER_LOCK_NAME;
+        document.head.appendChild(lockRef);
         break;
       }
 
       case Theme.Light: {
-        if (lightClass) {
-          element.classList.add(lightClass);
-        }
-
-        if (darkClass) {
-          element.classList.remove(darkClass);
-        }
-
-        const darkReaderLock = document.querySelector('head > meta[name=darkreader-lock]');
-        if (darkReaderLock) {
-          document.head.removeChild(darkReaderLock);
+        element.classList.add(LIGHT_CLASS);
+        element.classList.remove(DARK_CLASS);
+        const lockRef = document.querySelector(`head > meta[name=${DARK_READER_LOCK_NAME}]`);
+        if (lockRef) {
+          document.head.removeChild(lockRef);
         }
 
         break;

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -42,6 +42,12 @@ export enum Theme {
   Dark = 'dark',
 }
 
+export enum ThemePreference {
+  Light = 'light',
+  Dark = 'dark',
+  System = 'system',
+}
+
 export type TranslationProps<T extends keyof Translations> = { [K in T]?: string };
 
 export type IconLike = string | { path: string };

--- a/packages/ui/src/routes/+layout.svelte
+++ b/packages/ui/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
     SiteFooter,
     Text,
     themeManager,
+    ThemePreference,
     ThemeSwitcher,
     toastManager,
     TooltipProvider,
@@ -48,10 +49,9 @@
     }
   });
 
-  themeManager.initialize();
   toastManager.setOptions({ class: 'top-[58px]' });
 
-  const commands: ActionItem[] = [
+  const commands: ActionItem[] = $derived([
     {
       icon: mdiThemeLightDark,
       iconClass: 'text-gray-700 dark:text-gray-200',
@@ -64,14 +64,20 @@
       onAction: () => themeManager.toggle(),
       searchText: asText('Command', 'light', 'dark', 'theme', 'toggle'),
     },
-
+    {
+      icon: mdiThemeLightDark,
+      iconClass: 'text-gray-700 dark:text-gray-200',
+      title: 'System theme',
+      description: `Use the system theme (${themeManager.prefersDark ? 'dark' : ' light'})`,
+      onAction: () => themeManager.setPreference(ThemePreference.System),
+    },
     {
       title: 'Toggle screencast mode',
       description: 'Show/hide keyboard and mouse events on the screen',
       icon: mdiKeyboard,
       onAction: () => screencastManager.toggle(),
     },
-  ];
+  ]);
 
   commandPaletteManager.enable();
   commandPaletteManager.setTranslations({


### PR DESCRIPTION
More theme breaking changes
- Add support for system theme, which uses media queries
- Dynamically change theme when system theme changes
- Persist to storage as `dark | light | system`
- Toggle theme goes between dark and light
- Command palette can be used to set to system theme again