### PR TITLE
refactor: site commands

### DIFF
--- a/packages/ui/src/docs/constants.ts
+++ b/packages/ui/src/docs/constants.ts
@@ -2,6 +2,7 @@ import { goto } from '$app/navigation';
 import { asComponentHref } from '$docs/utilities.js';
 import {
   asText,
+  defaultProvider,
   MenuItemType,
   toastManager,
   type ActionItem,
@@ -319,18 +320,22 @@ const asCommand = (group: ComponentGroup, component: ComponentItem): ActionItem 
     title: component.name,
     description: `View the ${component.name} component`,
     onAction: () => goto(href),
-    searchText: asText('Component', group.title, component.name, href),
+    extraText: asText('Component', group.title, href),
   };
 };
 
-export const componentCommands: ActionItem[] = [];
+export const getComponentProvider = () => {
+  const commands: ActionItem[] = [];
 
-// components
-for (const group of componentGroups) {
-  for (const component of group.components) {
-    componentCommands.push(asCommand(group, component));
-    for (const item of component.items ?? []) {
-      componentCommands.push(asCommand(group, item));
+  // components
+  for (const group of componentGroups) {
+    for (const component of group.components) {
+      commands.push(asCommand(group, component));
+      for (const item of component.items ?? []) {
+        commands.push(asCommand(group, item));
+      }
     }
   }
-}
+
+  return defaultProvider({ name: 'Components', types: ['c', 'component', 'components'], actions: commands });
+};

--- a/packages/ui/src/lib/commands.ts
+++ b/packages/ui/src/lib/commands.ts
@@ -1,0 +1,191 @@
+import { defaultProvider } from '$lib/services/command-palette-manager.svelte.js';
+import { screencastManager } from '$lib/services/screencast-manager.svelte.js';
+import { themeManager } from '$lib/services/theme-manager.svelte.js';
+import { Constants } from '$lib/site/constants.js';
+import { ThemePreference, type ActionItem, type LinkItem } from '$lib/types.js';
+import { isExternalLink, navigateTo, resolveUrl } from '$lib/utilities/common.js';
+import { mdiKeyboard, mdiOpenInNew, mdiThemeLightDark } from '@mdi/js';
+
+export const linkCommands = (items: LinkItem[]): ActionItem[] => {
+  return items.map(linkCommand);
+};
+
+export const linkCommand = (item: LinkItem): ActionItem => ({
+  icon: isExternalLink(resolveUrl(item.href)) ? mdiOpenInNew : undefined,
+  iconClass: 'text-indigo-700 dark:text-indigo-200',
+  title: item.title,
+  description: item.description,
+  onAction: () => navigateTo(item.href),
+  extraText: item.href,
+});
+
+export const CORE_PAGE_COMMANDS = linkCommands([
+  {
+    title: 'Documentation',
+    description: 'View the documentation for Immich',
+    href: Constants.Sites.Docs,
+  },
+  {
+    title: 'Blog',
+    description: 'Latest updates, announcements, and stories from the Immich team',
+    href: Constants.Pages.Blog,
+  },
+  {
+    title: 'Cursed Knowledge',
+    description: 'View our collection of cursed knowledge',
+    href: Constants.Pages.CursedKnowledge,
+  },
+  {
+    title: 'Roadmap',
+    description: 'View our project roadmap',
+    href: Constants.Pages.Roadmap,
+  },
+  {
+    title: 'Privacy Policy',
+    description: 'View how we collect, use, and share information when you use Immich',
+    href: Constants.Pages.PrivacyPolicy,
+  },
+]);
+
+export const PROJECT_SUPPORT_COMMANDS = linkCommands([
+  {
+    title: 'Buy Immich',
+    description: 'Support Immich by buying a product key.',
+    href: Constants.Sites.Buy,
+  },
+  {
+    title: 'Immich Store',
+    description: 'Support the project by purchasing Immich merchandise',
+    href: Constants.Sites.Store,
+  },
+  {
+    title: 'Immich Datasets',
+    description: 'Help improve Immich by contributing your own files',
+    href: Constants.Sites.Datasets,
+  },
+]);
+
+export const MOBILE_APP_COMMANDS = linkCommands([
+  {
+    title: 'Immich on the PlayStore',
+    description: 'View Immich on the Google Play Store',
+    href: Constants.Get.Android,
+  },
+  {
+    title: 'Immich on the iOS App Store',
+    description: 'View Immich on the iOS App Store',
+    href: Constants.Get.iOS,
+  },
+]);
+
+export const OTHER_SITE_COMMANDS = linkCommands([
+  {
+    title: 'Awesome Immich',
+    description: 'A list of awesome Immich apps, integrations, tools, distributions, and guides',
+    href: Constants.Sites.Awesome,
+  },
+  {
+    title: 'Buy Immich',
+    description: 'Support Immich by buying a product key.',
+    href: Constants.Sites.Buy,
+  },
+  {
+    title: 'Get Immich',
+    description: 'View downloads links for Immich apps and server',
+    href: Constants.Sites.Get,
+  },
+  {
+    title: 'My Immich',
+    description: 'Immich link proxy to redirect to your personal instance',
+    href: Constants.Sites.My,
+  },
+  {
+    title: 'Immich API',
+    description: 'Documentation for the REST API that powers Immich',
+    href: Constants.Sites.Api,
+  },
+  {
+    title: 'Immich Data',
+    description: 'View interesting data about the growth of Immich over time',
+    href: Constants.Sites.Data,
+  },
+  {
+    title: 'Immich Documentation',
+    description: 'View the documentation for Immich',
+    href: Constants.Sites.Docs,
+  },
+  {
+    title: 'Immich Demo',
+    description: 'Test out Immich with our public demo server',
+    href: Constants.Sites.Demo,
+  },
+  {
+    title: 'Immich UI',
+    description: 'View our Svelte component library, @immich/ui',
+    href: Constants.Sites.Ui,
+  },
+]);
+
+export const SOCIAL_COMMANDS = linkCommands([
+  {
+    title: 'reddit',
+    description: 'Join the Immich community on reddit',
+    href: Constants.Socials.Reddit,
+  },
+  {
+    title: 'GitHub',
+    description: 'View our project on GitHub',
+    href: Constants.Socials.Github,
+  },
+  {
+    title: 'Discord',
+    description: 'Join the conversation on Discord',
+    href: Constants.Socials.Discord,
+  },
+  {
+    title: 'Weblate',
+    description: 'Support the project by translating Immich on Weblate',
+    href: Constants.Socials.Weblate,
+  },
+  {
+    title: 'FUTO',
+    description: 'Learn more about FUTO, the company behind Immich',
+    href: Constants.Sites.Docs,
+  },
+]);
+
+// for reactivity
+export const getSettingCommands = (): ActionItem[] => [
+  {
+    icon: mdiThemeLightDark,
+    iconClass: 'text-gray-700 dark:text-gray-200',
+    title: 'Toggle theme',
+    description: 'Switch between light and dark theme',
+    shortcuts: [{ alt: true, key: 't' }],
+    onAction: () => themeManager.toggle(),
+  },
+  {
+    icon: mdiThemeLightDark,
+    iconClass: 'text-gray-700 dark:text-gray-200',
+    title: 'System theme',
+    description: `Use the system theme (${themeManager.prefersDark ? 'dark' : ' light'})`,
+    tags: themeManager.preference === ThemePreference.System ? ['Active'] : undefined,
+    onAction: () => themeManager.setPreference(ThemePreference.System),
+  },
+  {
+    title: `Toggle screencast mode`,
+    description: 'Show/hide keyboard and mouse events on the screen',
+    icon: mdiKeyboard,
+    tags: screencastManager.enabled ? ['Active'] : undefined,
+    onAction: () => screencastManager.toggle(),
+  },
+];
+
+export const getSiteProviders = () => [
+  defaultProvider({ name: 'Pages', types: ['page', 'pages'], actions: CORE_PAGE_COMMANDS }),
+  defaultProvider({ name: 'Support', actions: PROJECT_SUPPORT_COMMANDS }),
+  defaultProvider({ name: 'Socials', types: ['social', 'socials'], actions: SOCIAL_COMMANDS }),
+  defaultProvider({ name: 'Mobile App', actions: MOBILE_APP_COMMANDS }),
+  defaultProvider({ name: 'Sites', types: ['site', 'sites'], actions: OTHER_SITE_COMMANDS }),
+  defaultProvider({ name: 'Settings', types: ['setting', 'settings'], actions: getSettingCommands() }),
+];

--- a/packages/ui/src/lib/components/CommandPalette/CommandPaletteDefaultProvider.svelte
+++ b/packages/ui/src/lib/components/CommandPalette/CommandPaletteDefaultProvider.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
   import CommandPaletteProvider from '$lib/components/CommandPalette/CommandPaletteProvider.svelte';
-  import { defaultProvider } from '$lib/services/command-palette-manager.svelte.js';
-  import type { ActionItem } from '$lib/types.js';
+  import { defaultProvider, type ActionDefaultProviderOptions } from '$lib/services/command-palette-manager.svelte.js';
 
-  type Props = {
-    name?: string;
-    actions?: ActionItem[];
-  };
-
-  const { name, actions = [] }: Props = $props();
+  const options: ActionDefaultProviderOptions = $props();
 </script>
 
-<CommandPaletteProvider providers={[defaultProvider({ name, actions })]} />
+<CommandPaletteProvider providers={[defaultProvider(options)]} />

--- a/packages/ui/src/lib/components/CommandPalette/CommandPaletteItem.svelte
+++ b/packages/ui/src/lib/components/CommandPalette/CommandPaletteItem.svelte
@@ -5,7 +5,7 @@
   import Icon from '$lib/components/Icon/Icon.svelte';
   import Kbd from '$lib/components/Kbd/Kbd.svelte';
   import Text from '$lib/components/Text/Text.svelte';
-  import type { ActionItem } from '$lib/types.js';
+  import type { ActionItem, ActionItemTag } from '$lib/types.js';
 
   type Props = {
     item: ActionItem;
@@ -27,6 +27,9 @@
       ref.scrollIntoView({ block: 'nearest', inline: 'start', behavior: 'smooth' });
     }
   });
+
+  const normalizeTags = (tags: Array<string | ActionItemTag>) =>
+    tags.map((tag) => (typeof tag === 'string' ? { value: tag } : tag)) as ActionItemTag[];
 </script>
 
 <div bind:this={ref} class="p-1">
@@ -53,9 +56,13 @@
           color="muted">{item.description}</Text
         >
       {/if}
-      {#if item.type}
+      {#if item.tags && item.tags.length > 0}
         <div class="mt-2">
-          <Badge color="primary" size="small" shape="round">{item.type}</Badge>
+          {#each normalizeTags(item.tags) as tag (tag.value)}
+            <Badge color={tag.color ?? 'primary'} size="small" shape={tag.shape ?? 'round'} class={tag.class}
+              >{tag.value}</Badge
+            >
+          {/each}
         </div>
       {/if}
     </div>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -105,6 +105,7 @@ export { default as TooltipProvider } from '$lib/components/Tooltip/TooltipProvi
 
 // helpers
 export * from '$lib/actions/shortcut.js';
+export * from '$lib/commands.js';
 export * from '$lib/services/command-palette-manager.svelte.js';
 export * from '$lib/services/menu-manager.svelte.js';
 export * from '$lib/services/modal-manager.svelte.js';

--- a/packages/ui/src/lib/services/command-palette-manager.svelte.ts
+++ b/packages/ui/src/lib/services/command-palette-manager.svelte.ts
@@ -19,14 +19,20 @@ export type CommandPaletteTranslations = TranslationProps<
 
 export type ActionProvider = {
   name?: string;
+  types?: string[];
   onSearch: (query?: string) => MaybePromise<ActionItem[]>;
 };
 
-export const defaultProvider = ({ name, actions }: { name?: string; actions: ActionItem[] }) => ({
+export type ActionDefaultProviderOptions = Omit<ActionProvider, 'onSearch'> & { actions: ActionItem[] };
+
+export const defaultProvider = ({ name, types, actions }: ActionDefaultProviderOptions) => ({
   name,
+  types,
   onSearch: (query?: string) =>
     query ? actions.filter((action) => getSearchString(action).includes(query.toLowerCase())) : actions,
 });
+
+const TYPE_REGEX = /type:("(?<quoted>[^"]+)"|(?<plain>\S+))/g;
 
 class CommandPaletteManager {
   #translations: CommandPaletteTranslations = {};
@@ -75,15 +81,26 @@ class CommandPaletteManager {
   }
 
   async #onSearch(query?: string) {
-    const newResults = await Promise.all(
-      this.#providers.map(async (provider) => {
-        const items = await provider.onSearch(query);
+    let type: string | undefined;
+    if (query) {
+      for (const matches of query.matchAll(TYPE_REGEX)) {
+        query = query.replaceAll(TYPE_REGEX, '');
+        type = matches.groups?.quoted ?? matches.groups?.plain;
+        break;
+      }
+    }
 
-        return {
-          provider,
-          items: items.filter((item) => isEnabled(item)).map((item) => ({ ...item, id: generateId() })),
-        };
-      }),
+    const newResults = await Promise.all(
+      this.#providers
+        .filter(({ types }) => !type || (types && types.includes(type)))
+        .map(async (provider) => {
+          const items = await provider.onSearch(query);
+
+          return {
+            provider,
+            items: items.filter((item) => isEnabled(item)).map((item) => ({ ...item, id: generateId() })),
+          };
+        }),
     );
 
     this.#selectedGroupIndex = 0;

--- a/packages/ui/src/lib/services/screencast-manager.svelte.ts
+++ b/packages/ui/src/lib/services/screencast-manager.svelte.ts
@@ -14,6 +14,10 @@ class ScreencastManager {
     return this.#events.map(({ event }) => event);
   }
 
+  get enabled() {
+    return this.#enabled.current;
+  }
+
   toggle() {
     this.#enabled.current = !this.#enabled.current;
     this.#events = [];

--- a/packages/ui/src/lib/services/theme-manager.svelte.ts
+++ b/packages/ui/src/lib/services/theme-manager.svelte.ts
@@ -37,6 +37,10 @@ class ThemeManager {
     return this.#darkModeUser.current;
   }
 
+  get preference() {
+    return this.#theme.current;
+  }
+
   get value() {
     switch (this.#theme.current) {
       case ThemePreference.System: {

--- a/packages/ui/src/lib/site/constants.ts
+++ b/packages/ui/src/lib/site/constants.ts
@@ -1,6 +1,3 @@
-import { asText, navigateTo } from '$lib/utilities/common.js';
-import { mdiOpenInNew } from '@mdi/js';
-
 export const Constants = {
   Socials: {
     Futo: 'https://futo.org/',
@@ -34,6 +31,7 @@ export const Constants = {
     Ui: 'https://ui.immich.app/',
   },
   Pages: {
+    Blog: 'https://immich.app/blog',
     CursedKnowledge: 'https://immich.app/cursed-knowledge',
     Roadmap: 'https://immich.app/roadmap',
     PrivacyPolicy: 'https://immich.app/privacy-policy',
@@ -43,98 +41,3 @@ export const Constants = {
     Ui: 'https://www.npmjs.com/package/@immich/ui',
   },
 };
-
-export const siteCommands = [
-  {
-    title: 'Immich Documentation',
-    description: 'View the Immich documentation',
-    href: Constants.Sites.Docs,
-  },
-  {
-    title: 'Buy Immich',
-    description: 'Support Immich by buying a product key.',
-    href: Constants.Sites.Buy,
-  },
-  {
-    title: 'My Immich',
-    description: 'Immich link proxy to redirect to your personal instance',
-    href: Constants.Sites.My,
-  },
-  {
-    title: 'Get Immich',
-    description: 'View downloads links for Immich apps and server',
-    href: Constants.Sites.Get,
-  },
-  {
-    title: 'Immich on the PlayStore',
-    description: 'View Immich on the Google Play Store',
-    href: Constants.Get.Android,
-  },
-  {
-    title: 'Immich on the iOS App Store',
-    description: 'View Immich on the iOS App Store',
-    href: Constants.Get.iOS,
-  },
-  {
-    title: 'Immich Demo',
-    description: 'Test out Immich with our public demo server',
-    href: Constants.Sites.Demo,
-  },
-  {
-    title: 'Immich Store',
-    description: 'Support the project by purchasing Immich merchandise',
-    href: Constants.Sites.Store,
-  },
-  {
-    title: 'Immich Datasets',
-    description: 'Help improve Immich by contributing your own files',
-    href: Constants.Sites.Datasets,
-  },
-  {
-    title: 'Immich UI',
-    description: 'View our Svelte component library, @immich/ui',
-    href: Constants.Sites.Ui,
-  },
-  {
-    title: 'Cursed Knowledge',
-    description: 'View our collection of cursed knowledge',
-    href: Constants.Pages.CursedKnowledge,
-  },
-  {
-    title: 'Roadmap',
-    description: 'View our project roadmap',
-    href: Constants.Pages.Roadmap,
-  },
-  {
-    title: 'reddit',
-    description: 'Join the Immich community on reddit',
-    href: Constants.Socials.Reddit,
-  },
-  {
-    title: 'GitHub',
-    description: 'View our project on GitHub',
-    href: Constants.Socials.Github,
-  },
-  {
-    title: 'Discord',
-    description: 'Join the conversation on Discord',
-    href: Constants.Socials.Discord,
-  },
-  {
-    title: 'Weblate',
-    description: 'Support the project by translating Immich on Weblate',
-    href: Constants.Socials.Weblate,
-  },
-  {
-    title: 'FUTO',
-    description: 'Learn more about FUTO, the company behind Immich',
-    href: Constants.Sites.Docs,
-  },
-].map((site) => ({
-  icon: mdiOpenInNew,
-  iconClass: 'text-indigo-700 dark:text-indigo-200',
-  title: site.title,
-  description: site.description,
-  onAction: () => navigateTo(site.href),
-  searchText: asText('Site', 'Link', site.title, site.description, site.href),
-}));

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -361,11 +361,24 @@ export type IfLike = { $if?: () => boolean };
 
 export type ActionItemHandler<T extends ActionItem = ActionItem> = (item: T) => unknown | Promise<unknown>;
 
+export type LinkItem = {
+  title: string;
+  description: string;
+  href: string;
+};
+
+export type ActionItemTag = {
+  value: string;
+  color?: Color;
+  shape: Shape;
+  class?: string;
+};
+
 export type ActionItem = {
   title: string;
   description?: string;
-  type?: string;
-  searchText?: string;
+  extraText?: string | string[];
+  tags?: Array<string | ActionItemTag>;
   icon?: IconLike;
   iconClass?: string;
   color?: Color;

--- a/packages/ui/src/lib/utilities/internal.ts
+++ b/packages/ui/src/lib/utilities/internal.ts
@@ -49,5 +49,6 @@ export const resolveIcon = ({
 
 export const asArray = <T>(items?: MaybeArray<T>) => (Array.isArray(items) ? items : items ? [items] : []);
 
-export const getSearchString = ({ title, description, type, searchText }: ActionItem) =>
-  searchText ?? asText(title, description, type);
+const normalize = <T = unknown>(items: T | T[] | undefined) => (items ? asArray(items) : []);
+export const getSearchString = ({ title, description, tags, extraText }: ActionItem) =>
+  asText(title, description, ...normalize(tags), ...normalize(extraText));

--- a/packages/ui/src/routes/+layout.svelte
+++ b/packages/ui/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
   import { beforeNavigate } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import { componentCommands, componentGroups } from '$docs/constants.js';
+  import { componentGroups, getComponentProvider } from '$docs/constants.js';
   import { asComponentHref } from '$docs/utilities.js';
   import CommandPaletteProvider from '$lib/components/CommandPalette/CommandPaletteProvider.svelte';
   import '$lib/theme/default.css';
@@ -10,31 +10,25 @@
     AppShell,
     AppShellHeader,
     AppShellSidebar,
-    asText,
     commandPaletteManager,
     ControlBar,
     ControlBarHeader,
     ControlBarOverflow,
-    defaultProvider,
+    getSiteProviders,
     Icon,
     IconButton,
     Logo,
     NavbarGroup,
     NavbarItem,
-    screencastManager,
     ScreencastOverlay,
-    siteCommands,
     SiteFooter,
     Text,
-    themeManager,
-    ThemePreference,
     ThemeSwitcher,
     toastManager,
     TooltipProvider,
-    type ActionItem,
     type NavbarProps,
   } from '@immich/ui';
-  import { mdiHome, mdiHomeOutline, mdiKeyboard, mdiMagnify, mdiMenu, mdiThemeLightDark } from '@mdi/js';
+  import { mdiHome, mdiHomeOutline, mdiMagnify, mdiMenu } from '@mdi/js';
   import { MediaQuery } from 'svelte/reactivity';
   import '../app.css';
 
@@ -51,47 +45,13 @@
 
   toastManager.setOptions({ class: 'top-[58px]' });
 
-  const commands: ActionItem[] = $derived([
-    {
-      icon: mdiThemeLightDark,
-      iconClass: 'text-gray-700 dark:text-gray-200',
-      title: 'Toggle theme',
-      description: 'Switch between light and dark theme',
-      shortcuts: [
-        { shift: true, key: 't' },
-        { alt: true, key: 't' },
-      ],
-      onAction: () => themeManager.toggle(),
-      searchText: asText('Command', 'light', 'dark', 'theme', 'toggle'),
-    },
-    {
-      icon: mdiThemeLightDark,
-      iconClass: 'text-gray-700 dark:text-gray-200',
-      title: 'System theme',
-      description: `Use the system theme (${themeManager.prefersDark ? 'dark' : ' light'})`,
-      onAction: () => themeManager.setPreference(ThemePreference.System),
-    },
-    {
-      title: 'Toggle screencast mode',
-      description: 'Show/hide keyboard and mouse events on the screen',
-      icon: mdiKeyboard,
-      onAction: () => screencastManager.toggle(),
-    },
-  ]);
-
   commandPaletteManager.enable();
   commandPaletteManager.setTranslations({
     command_palette_prompt_default: 'Quickly find components, links, and commands',
   });
 </script>
 
-<CommandPaletteProvider
-  providers={[
-    defaultProvider({ name: 'Commands', actions: commands }),
-    defaultProvider({ name: 'Components', actions: componentCommands }),
-    defaultProvider({ name: 'Links', actions: siteCommands }),
-  ]}
-/>
+<CommandPaletteProvider providers={[getComponentProvider(), ...getSiteProviders()]} />
 
 <ScreencastOverlay />
 

--- a/packages/ui/src/routes/components/command-palette/BasicExample.svelte
+++ b/packages/ui/src/routes/components/command-palette/BasicExample.svelte
@@ -8,7 +8,8 @@
 
 <HStack wrap>
   <Button onclick={() => onSearch('')}>Open</Button>
-  <Button onclick={() => onSearch('site')}>View sites</Button>
-  <Button onclick={() => onSearch('command')}>View commands</Button>
-  <Button onclick={() => onSearch('component')}>View components</Button>
+  <Button onclick={() => onSearch('type:setting')}>View settings</Button>
+  <Button onclick={() => onSearch('type:site')}>View sites</Button>
+  <Button onclick={() => onSearch('type:social')}>View socials</Button>
+  <Button onclick={() => onSearch('type:project')}>View project pages</Button>
 </HStack>

--- a/packages/ui/src/routes/components/modal/NestedModal.svelte
+++ b/packages/ui/src/routes/components/modal/NestedModal.svelte
@@ -30,7 +30,7 @@
           description: 'Open nested confirm dialog',
           icon: mdiCheck,
           iconClass: '',
-          type: 'Type',
+          tags: ['Tag'],
         },
       ]}
       name="Example"


### PR DESCRIPTION
- Add new site commands
- Split site commands into groups
- Replace `searchText` with `extraText`
- Update `item.type` to `item.tags`
- Add `provider.types` for filtering with `type:{value}`