### PR TITLE
fix(textarea): dont resize textarea when its not visible

### DIFF
--- a/packages/ui/src/lib/components/Textarea/Textarea.svelte
+++ b/packages/ui/src/lib/components/Textarea/Textarea.svelte
@@ -82,25 +82,27 @@
   };
 
   const autogrow = (element: HTMLTextAreaElement | null) => {
-    if (element && grow) {
-      element.style.minHeight = '0';
-      element.style.height = 'auto';
+    if (!element || !grow || element.scrollHeight === 0) {
+      return;
+    }
 
-      const style = getComputedStyle(element);
-      const borderTopWidth = parseStyleNumber(style.borderTopWidth) ?? 0;
-      const borderBottomWidth = parseStyleNumber(style.borderBottomWidth) ?? 0;
-      const height = element.scrollHeight + borderTopWidth + borderBottomWidth;
+    element.style.minHeight = '0';
+    element.style.height = 'auto';
 
-      element.style.height = `${height}px`;
+    const style = getComputedStyle(element);
+    const borderTopWidth = parseStyleNumber(style.borderTopWidth) ?? 0;
+    const borderBottomWidth = parseStyleNumber(style.borderBottomWidth) ?? 0;
+    const height = element.scrollHeight + borderTopWidth + borderBottomWidth;
 
-      // Show scrollbar only if there is a max-height and content exceeds it
-      const maxHeight = parseStyleNumber(style.maxHeight);
-      const hasMaxHeight = maxHeight !== undefined;
-      if (hasMaxHeight && height > maxHeight) {
-        element.style.overflow = 'auto';
-      } else {
-        element.style.overflow = 'hidden';
-      }
+    element.style.height = `${height}px`;
+
+    // Show scrollbar only if there is a max-height and content exceeds it
+    const maxHeight = parseStyleNumber(style.maxHeight);
+    const hasMaxHeight = maxHeight !== undefined;
+    if (hasMaxHeight && height > maxHeight) {
+      element.style.overflow = 'auto';
+    } else {
+      element.style.overflow = 'hidden';
     }
   };
 


### PR DESCRIPTION
## Description

This is PR 1 of 2 for solving the issue https://github.com/immich-app/immich/issues/27631

The bug fixed here is visual - the Textarea component resizes itself incorrectly when hidden by the asset viewer.

When the user opens the asset viewer, the Textarea resizes itself to 0. When the asset viewer closes again, it does not resize itself correctly afterwards.

This change prevents resizing when the Textarea is hidden.

## How Has This Been Tested?

This was tested using the same reproduction instructions as in the original issue:

> Create an album with an asset
> Add a description to the album. I added test\nhello.
> Open image
> Close image
> Album description is not properly shown

It should be noted that there is still a bug after making this change - the content of the album description reverts to the pre-updated version. Fixing that is code within the immich repo itself, and is a separate issue.

## Checklist:

- [x] I have carefully read CONTRIBUTING.md
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [x] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

I am not a wizard with DOM element properties - an LLM helped me identify the scrollHeight property for detecting hidden elements. The decision to move the if block to a guard which returns early was mine.