### PR TITLE
chore: tweak immich-ui-gray color

### DIFF
--- a/packages/ui/src/lib/site/SiteFooter.svelte
+++ b/packages/ui/src/lib/site/SiteFooter.svelte
@@ -8,7 +8,7 @@
   import { siDiscord, siGithub, siReddit, siRss, siWeblate, siX, siYoutube } from 'simple-icons';
 </script>
 
-<div class="mt-16 rounded-t-md bg-gray-50 p-8 lg:p-4 lg:py-8 dark:bg-neutral-900">
+<div class="dark:bg-subtle mt-16 rounded-t-md bg-gray-50 p-8 lg:p-4 lg:py-8">
   <div class="mx-auto max-w-(--breakpoint-lg)">
     <Stack gap={8}>
       <div class="place-center grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">

--- a/packages/ui/src/lib/theme/default.css
+++ b/packages/ui/src/lib/theme/default.css
@@ -292,7 +292,7 @@
     --immich-ui-light: oklch(0% 0 0);
     --immich-ui-dark: oklch(89% 0 271);
     --immich-ui-muted: oklch(87% 0 271);
-    --immich-ui-gray: oklch(25% 0 271);
+    --immich-ui-gray: oklch(17.89% 0.0104 276.38);
     --immich-ui-default-border: var(--immich-ui-light-200);
   }
 


### PR DESCRIPTION
Make immich-ui-gray in dark theme has a bit more blue tint to fit with the primary color

| Before | After |
| - | - |
| <img width="1144" height="848" alt="image" src="https://github.com/user-attachments/assets/2b6f5231-8b2e-4ea3-afad-5f67c2d36594" /> | <img width="1148" height="852" alt="image" src="https://github.com/user-attachments/assets/480c5507-2a7f-4808-a537-bc2348bf166c" /> |
